### PR TITLE
Update cron.php

### DIFF
--- a/lib/cron.php
+++ b/lib/cron.php
@@ -257,7 +257,7 @@ class Cron extends \Prefab {
             foreach($config['presets'] as $name=>$expr)
                 $this->preset($name,is_array($expr)?implode(',',$expr):$expr);
         $this->windows=(bool)preg_match('/^win/i',PHP_OS);
-        $f3->route(['GET /cron','GET /cron/@job'],[$this,'route']);
+        $f3->route(['GET|HEAD /cron','GET|HEAD /cron/@job'],[$this,'route']);
     }
 
 }


### PR DESCRIPTION
some shared space hosting providers like Webglobe in Slovakia require that cron URL is accessible via HEAD to enable CRON job from their WebUI Admin panels